### PR TITLE
Fix broken filtering for images used by containers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,4 +48,6 @@ def later_time():
 
 @pytest.fixture
 def mock_client():
-    return mock.create_autospec(docker.Client)
+    client = mock.create_autospec(docker.Client)
+    client._version = '1.17'
+    return client


### PR DESCRIPTION
Error calling remove_image image=xxx:latest 409 Client Error: Conflict ("conflict: unable to remove repository reference "xxx:latest" (must force) - container 91ab644a7b31 is using its referenced image 7caea3c78386")